### PR TITLE
Fix f-string syntax errors

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,7 +6,7 @@ from models import Transaction
 
 def display_menu() -> None:
     print("")
-    print(f"{" MENÚ ":*^30}")
+    print(f"{' MENÚ ':*^30}")
     print("1. Agregar gasto")
     print("2. Agregar ingreso")
     print("3. Ver balance")

--- a/manager.py
+++ b/manager.py
@@ -184,7 +184,7 @@ class FinanceManager:
                 date_to=date_to
             )
 
-            print(f"\n{"TRANSACCIONES":*^70}")
+            print(f"\n{'TRANSACCIONES':*^70}")
             if results:
                 print(*results, sep="\n")
             else:


### PR DESCRIPTION
## Summary
- fix menu title formatting in `main.py`
- correct header printing in `manager.py`

## Testing
- `python -m py_compile main.py manager.py models.py tests/test_finance_manager.py`
- `PYTHONPATH=. pytest -q` *(fails: ModuleNotFoundError: No module named 'matplotlib')*

------
https://chatgpt.com/codex/tasks/task_e_68470061a788832abcd5f6592f065bea